### PR TITLE
Remove HasDurableWorkerCtx as it was not usable in practice

### DIFF
--- a/golem-common/proto/services/template_service.proto
+++ b/golem-common/proto/services/template_service.proto
@@ -10,6 +10,7 @@ import public "models/template_id.proto";
 import public "models/token_secret.proto";
 
 service TemplateService {
+  rpc GetTemplates (GetTemplatesRequest) returns (GetTemplatesResponse);
   rpc CreateTemplate (stream CreateTemplateRequest) returns (CreateTemplateResponse);
   rpc DownloadTemplate (DownloadTemplateRequest) returns (stream DownloadTemplateResponse);
   rpc GetTemplate (GetTemplateRequest) returns (GetTemplateResponse);

--- a/golem-worker-executor-base/src/workerctx.rs
+++ b/golem-worker-executor-base/src/workerctx.rs
@@ -284,7 +284,7 @@ pub trait ExternalOperations<Ctx: WorkerCtx> {
     async fn prepare_instance(
         worker_id: &VersionedWorkerId,
         instance: &wasmtime::component::Instance,
-        store: &mut (impl AsContextMut<Data = Self> + Send),
+        store: &mut (impl AsContextMut<Data = Ctx> + Send),
     ) -> Result<(), GolemError>;
 
     /// Records the last known resource limits of a worker without activating it

--- a/golem-worker-executor-base/tests/lib.rs
+++ b/golem-worker-executor-base/tests/lib.rs
@@ -1,6 +1,5 @@
 use ctor::{ctor, dtor};
 
-
 use redis::{Commands, RedisResult};
 use std::ops::Deref;
 use std::panic;

--- a/golem-worker-executor-base/tests/lib.rs
+++ b/golem-worker-executor-base/tests/lib.rs
@@ -1,6 +1,6 @@
 use ctor::{ctor, dtor};
-use fred::clients::RedisClient;
-use fred::prelude::RedisConfig;
+
+
 use redis::{Commands, RedisResult};
 use std::ops::Deref;
 use std::panic;

--- a/golem-worker-executor-oss/src/lib.rs
+++ b/golem-worker-executor-oss/src/lib.rs
@@ -98,10 +98,10 @@ impl Bootstrap<Context> for ServerBootstrap {
 
     fn create_wasmtime_linker(&self, engine: &Engine) -> anyhow::Result<Linker<Context>> {
         let mut linker =
-            create_linker::<Context, DurableWorkerCtx<Context>>(engine, |x| &mut x.golem_ctx)?;
+            create_linker::<Context, DurableWorkerCtx<Context>>(engine, |x| &mut x.durable_ctx)?;
         durable_host::host::add_to_linker::<Context, DurableWorkerCtx<Context>>(
             &mut linker,
-            |x| &mut x.golem_ctx,
+            |x| &mut x.durable_ctx,
         )?;
         Ok(linker)
     }


### PR DESCRIPTION
The generic way that was supposed to "auto implement" parts of `WorkerCtx` for the leaf contexts was not working in practice due to various ownership and coherence rules. 

So with this change the final context type requires manual implementation of the full worker context, but for each method which is not to be customized, it can be a single forward call to the inner `DurableWorkerCtx`. 