### PR TITLE
Return error when there is decode error for record

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,8 +42,8 @@ services:
       - GOLEM__GRPC_PORT=9090
       - GOLEM__HTTP_PORT=8080
     volumes:
-      - ./template_store:/template_store
-      - ./golem_db:/app/golem_db
+      - template_store:/template_store
+      - golem_db:/app/golem_db
     ports:
       - "8080:8080"
       - "9090:9090"
@@ -84,4 +84,8 @@ services:
 
 volumes:
   redis_data:
+    driver: local
   template_store:
+    driver: local
+  golem_db:
+    driver: local

--- a/golem-cloud-server-base/src/typechecker.rs
+++ b/golem-cloud-server-base/src/typechecker.rs
@@ -964,7 +964,12 @@ fn get_record(
         if let Some(json_value) = json_map.get(name) {
             match validate_function_parameters(json_value, tpe.clone()) {
                 Ok(result) => vals.push(VVal { val: Some(result) }),
-                Err(value_errors) => errors.extend(value_errors.iter().map(|err| format!("Invalid value for the key {}. Error: {}", name, err)).collect())
+                Err(value_errors) => errors.extend(
+                    value_errors
+                        .iter()
+                        .map(|err| format!("Invalid value for the key {}. Error: {}", name, err))
+                        .collect(),
+                ),
             }
         } else {
             errors.push(format!("Key '{}' not found in json_map", name));
@@ -1951,19 +1956,29 @@ mod tests {
         });
 
         let name_type_pairs: Vec<(&String, &Type)> = vec![
-            (&"key1".to_string(), &Type::Primitive(TypePrimitive {
-                primitive: PrimitiveType::Str as i32,
-            })),
-            (&"key2".to_string(), &Type::Primitive(TypePrimitive {
-                primitive: PrimitiveType::Str as i32,
-            })),
+            (
+                &"key1".to_string(),
+                &Type::Primitive(TypePrimitive {
+                    primitive: PrimitiveType::Str as i32,
+                }),
+            ),
+            (
+                &"key2".to_string(),
+                &Type::Primitive(TypePrimitive {
+                    primitive: PrimitiveType::Str as i32,
+                }),
+            ),
         ];
 
         let result = get_record(&input_json, name_type_pairs);
         let expected_result = Ok(ValRecord {
             values: vec![
-                VVal { val: Some(Val::String("value1".to_string())) },
-                VVal { val: Some(Val::String("value2".to_string())) },
+                VVal {
+                    val: Some(Val::String("value1".to_string())),
+                },
+                VVal {
+                    val: Some(Val::String("value2".to_string())),
+                },
             ],
         });
         assert_eq!(result, expected_result);
@@ -1972,7 +1987,6 @@ mod tests {
         let input_json = json!({
             "key1": "value1",
         });
-
 
         let result = get_record(&input_json, name_type_pairs);
         assert_eq!(result.is_err(), true);

--- a/golem-cloud-server-base/src/typechecker.rs
+++ b/golem-cloud-server-base/src/typechecker.rs
@@ -12,7 +12,6 @@ use num_traits::cast::FromPrimitive;
 use num_traits::ToPrimitive;
 use serde_json::{Number, Value};
 use std::str::FromStr;
-use tracing::error;
 
 pub trait TypeCheckIn {
     fn validate_function_parameters(
@@ -968,7 +967,7 @@ fn get_record(
                     value_errors
                         .iter()
                         .map(|err| format!("Invalid value for the key {}. Error: {}", name, err))
-                        .collect(),
+                        .collect::<Vec<_>>(),
                 ),
             }
         } else {
@@ -1965,22 +1964,25 @@ mod tests {
             "key2": "value2",
         });
 
+        let key1 = "key1".to_string();
+        let key2 = "key2".to_string();
+
         let name_type_pairs: Vec<(&String, &Type)> = vec![
             (
-                &"key1".to_string(),
+                &key1,
                 &Type::Primitive(TypePrimitive {
                     primitive: PrimitiveType::Str as i32,
                 }),
             ),
             (
-                &"key2".to_string(),
+                &key2,
                 &Type::Primitive(TypePrimitive {
                     primitive: PrimitiveType::Str as i32,
                 }),
             ),
         ];
 
-        let result = get_record(&input_json, name_type_pairs);
+        let result = get_record(&input_json, name_type_pairs.clone());
         let expected_result = Ok(ValRecord {
             values: vec![
                 VVal {
@@ -1998,7 +2000,7 @@ mod tests {
             "key1": "value1",
         });
 
-        let result = get_record(&input_json, name_type_pairs);
+        let result = get_record(&input_json, name_type_pairs.clone());
         assert_eq!(result.is_err(), true);
     }
 }

--- a/golem-cloud-server-base/src/typechecker.rs
+++ b/golem-cloud-server-base/src/typechecker.rs
@@ -956,19 +956,19 @@ fn get_record(
         input_json
     )])?;
 
-   let mut errors: Vec<String> = vec![];
-   let mut vals: Vec<VVal> = vec![];
+    let mut errors: Vec<String> = vec![];
+    let mut vals: Vec<VVal> = vec![];
 
-   for (name, tpe) in name_type_pairs {
-      if let Some(json_value) = json_map.get(name) {
-        match validate_function_parameters(json_value, tpe.clone()) {
-            Ok(result) => vals.push(VVal { val: Some(result) }),
-            Err(errs) => errors.extend(errs),
+    for (name, tpe) in name_type_pairs {
+        if let Some(json_value) = json_map.get(name) {
+            match validate_function_parameters(json_value, tpe.clone()) {
+                Ok(result) => vals.push(VVal { val: Some(result) }),
+                Err(errs) => errors.extend(errs),
+            }
+        } else {
+            errors.push(format!("Key '{}' not found in json_map", name));
         }
-    } else {
-        errors.push(format!("Key '{}' not found in json_map", name));
     }
-   }
 
     Ok(ValRecord { values: vals })
 }

--- a/golem-cloud-server-base/src/typechecker.rs
+++ b/golem-cloud-server-base/src/typechecker.rs
@@ -956,17 +956,19 @@ fn get_record(
         input_json
     )])?;
 
-    let mut errors: Vec<String> = vec![];
-    let mut vals: Vec<VVal> = vec![];
+   let mut errors: Vec<String> = vec![];
+   let mut vals: Vec<VVal> = vec![];
 
-    for (name, tpe) in name_type_pairs {
-        let json_value = json_map.get(name).unwrap_or(&Value::Null);
-
+   for (name, tpe) in name_type_pairs {
+      if let Some(json_value) = json_map.get(name) {
         match validate_function_parameters(json_value, tpe.clone()) {
             Ok(result) => vals.push(VVal { val: Some(result) }),
             Err(errs) => errors.extend(errs),
         }
+    } else {
+        errors.push(format!("Key '{}' not found in json_map", name));
     }
+   }
 
     Ok(ValRecord { values: vals })
 }

--- a/golem-cloud-server-base/src/typechecker.rs
+++ b/golem-cloud-server-base/src/typechecker.rs
@@ -972,7 +972,17 @@ fn get_record(
                 ),
             }
         } else {
-            errors.push(format!("Key '{}' not found in json_map", name));
+            match tpe {
+                Type::Option(_) => {
+                    vals.push(VVal {
+                        val: Some(Val::Option(Box::new(ValOption {
+                            discriminant: 0,
+                            value: None,
+                        }))),
+                    });
+                }
+                _ => errors.push(format!("Key '{}' not found in json_map", name)),
+            }
         }
     }
 

--- a/golem-worker-executor-base/src/wasm_types.rs
+++ b/golem-worker-executor-base/src/wasm_types.rs
@@ -132,8 +132,16 @@ pub fn decode_param(param: &golem::worker::Val, param_type: &Type) -> Result<Val
                             Ok((field.name, decoded_param))
                         })
                         .collect::<Result<Vec<(&str, Val)>, GolemError>>()?;
-                    let record =
-                        Record::new(ty, record_values).expect("Type mismatch in decode_param");
+
+                    let record = Record::new(ty, record_values).map_err(|err| {
+                        GolemError::ValueMismatch {
+                            details: format!(
+                                "Invalid record data in function parameters {}",
+                                err.to_string()
+                            ),
+                        }
+                    })?;
+
                     Ok(Val::Record(record))
                 }
                 _ => Err(GolemError::ParamTypeMismatch),

--- a/golem-worker-executor-base/src/wasm_types.rs
+++ b/golem-worker-executor-base/src/wasm_types.rs
@@ -135,10 +135,7 @@ pub fn decode_param(param: &golem::worker::Val, param_type: &Type) -> Result<Val
 
                     let record = Record::new(ty, record_values).map_err(|err| {
                         GolemError::ValueMismatch {
-                            details: format!(
-                                "Invalid record data in function parameters {}",
-                                err.to_string()
-                            ),
+                            details: format!("Invalid record data in function parameters {}", err),
                         }
                     })?;
 

--- a/golem-worker-executor-base/src/wasm_types.rs
+++ b/golem-worker-executor-base/src/wasm_types.rs
@@ -132,13 +132,8 @@ pub fn decode_param(param: &golem::worker::Val, param_type: &Type) -> Result<Val
                             Ok((field.name, decoded_param))
                         })
                         .collect::<Result<Vec<(&str, Val)>, GolemError>>()?;
-
-                    let record = Record::new(ty, record_values).map_err(|err| {
-                        GolemError::ValueMismatch {
-                            details: format!("Invalid record data in function parameters {}", err),
-                        }
-                    })?;
-
+                    let record =
+                        Record::new(ty, record_values).expect("Type mismatch in decode_param");
                     Ok(Val::Record(record))
                 }
                 _ => Err(GolemError::ParamTypeMismatch),


### PR DESCRIPTION
If we Invoke function with partial information in the function parameter which is of `Record` type, then golem-cli doesn't respond with any error and looks to be hanging forever.

This is a minor fix.

More details here: https://www.notion.so/golemcloud/Golem-OSS-CLI-Testing-893dbb95d2054044afdedc5a49906b9d

![image](https://github.com/golemcloud/golem-services/assets/7448613/5d21239c-816e-40f9-94e3-d005b3c83734)
