### PR TITLE
docker examples postgres - golem-service restart on failure

### DIFF
--- a/docker-examples/docker-compose-postgres.yaml
+++ b/docker-examples/docker-compose-postgres.yaml
@@ -37,6 +37,7 @@ services:
   golem-service:
     image: golemservices/golem-service:latest
     pull_policy: always
+    restart: on-failure
     environment:
       - ENVIRONMENT=local
       - WASMTIME_BACKTRACE_DETAILS=1


### PR DESCRIPTION
```cmd
docker-examples % docker-compose -f docker-compose-postgres.yaml up
```

failing with first start, as golem-service trying to init postgres db (migrations), which is not completely started yet

with restart on failure, golem-service will recover

```logs
golem-service-1          | 2024-02-03T18:54:51.020960Z  INFO golem_service::db: DB migration: postgresql://postgres:5432/golem_db
golem-service-1          | [golem-service/src/server.rs:51] "DB - init error: {}" = "DB - init error: {}"
golem-service-1          | [golem-service/src/server.rs:51] e = Io(
golem-service-1          |     Os {
golem-service-1          |         code: 111,
golem-service-1          |         kind: ConnectionRefused,
golem-service-1          |         message: "Connection refused",
golem-service-1          |     },
golem-service-1          | )
golem-service-1 exited with code 0
golem-service-1          | Error: Custom { kind: Other, error: "Init error" }
postgres-1               |  done
postgres-1               | server started
postgres-1               | CREATE DATABASE
postgres-1               |
postgres-1               |
postgres-1               | /usr/local/bin/docker-entrypoint.sh: ignoring /docker-entrypoint-initdb.d/*
postgres-1               |
postgres-1               | waiting for server to shut down...2024-02-03 18:54:51.221 UTC [48] LOG:  received fast shutdown request
postgres-1               | .2024-02-03 18:54:51.230 UTC [48] LOG:  aborting any active transactions
postgres-1               | 2024-02-03 18:54:51.231 UTC [48] LOG:  background worker "logical replication launcher" (PID 54) exited with exit code 1
postgres-1               | 2024-02-03 18:54:51.232 UTC [49] LOG:  shutting down
postgres-1               | 2024-02-03 18:54:51.236 UTC [49] LOG:  checkpoint starting: shutdown immediate
golem-service-1          | 2024-02-03T18:54:49.945138Z  INFO golem_service: Starting cloud server on ports: http: 9881, grpc: 9090
golem-service-1          | 2024-02-03T18:54:49.945171Z  INFO golem_service::db: DB migration: postgresql://postgres:5432/golem_db
golem-service-1          | [golem-service/src/server.rs:51] "DB - init error: {}" = "DB - init error: {}"
golem-service-1          | [golem-service/src/server.rs:51] e = Io(
golem-service-1          |     Os {
golem-service-1          |         code: 111,
golem-service-1          |         kind: ConnectionRefused,
golem-service-1          |         message: "Connection refused",
golem-service-1          |     },
golem-service-1          | )
golem-service-1          | Error: Custom { kind: Other, error: "Init error" }
golem-service-1          | 2024-02-03T18:54:50.517263Z  INFO golem_service: Starting cloud server on ports: http: 9881, grpc: 9090
golem-service-1          | 2024-02-03T18:54:50.517288Z  INFO golem_service::db: DB migration: postgresql://postgres:5432/golem_db
golem-service-1          | [golem-service/src/server.rs:51] "DB - init error: {}" = "DB - init error: {}"
golem-service-1          | [golem-service/src/server.rs:51] e = Io(
golem-service-1          |     Os {
golem-service-1          |         code: 111,
golem-service-1          |         kind: ConnectionRefused,
golem-service-1          |         message: "Connection refused",
golem-service-1          |     },
golem-service-1          | )
golem-service-1          | Error: Custom { kind: Other, error: "Init error" }
golem-service-1          | 2024-02-03T18:54:51.020918Z  INFO golem_service: Starting cloud server on ports: http: 9881, grpc: 9090
golem-service-1          | 2024-02-03T18:54:51.020960Z  INFO golem_service::db: DB migration: postgresql://postgres:5432/golem_db
golem-service-1          | [golem-service/src/server.rs:51] "DB - init error: {}" = "DB - init error: {}"
golem-service-1          | [golem-service/src/server.rs:51] e = Io(
golem-service-1          |     Os {
golem-service-1          |         code: 111,
golem-service-1          |         kind: ConnectionRefused,
golem-service-1          |         message: "Connection refused",
golem-service-1          |     },
golem-service-1          | )
golem-service-1          | Error: Custom { kind: Other, error: "Init error" }
golem-service-1 exited with code 1
postgres-1               | 2024-02-03 18:54:51.302 UTC [49] LOG:  checkpoint complete: wrote 918 buffers (5.6%); 0 WAL file(s) added, 0 removed, 0 recycled; write=0.019 s, sync=0.039 s, total=0.071 s; sync files=250, longest=0.013 s, average=0.001 s; distance=4217 kB, estimate=4217 kB
postgres-1               | 2024-02-03 18:54:51.306 UTC [48] LOG:  database system is shut down
postgres-1               |  done
postgres-1               | server stopped
postgres-1               |
postgres-1               | PostgreSQL init process complete; ready for start up.
postgres-1               |
postgres-1               | 2024-02-03 18:54:51.342 UTC [1] LOG:  starting PostgreSQL 15.2 (Debian 15.2-1.pgdg110+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit
postgres-1               | 2024-02-03 18:54:51.342 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
postgres-1               | 2024-02-03 18:54:51.342 UTC [1] LOG:  listening on IPv6 address "::", port 5432
postgres-1               | 2024-02-03 18:54:51.345 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
postgres-1               | 2024-02-03 18:54:51.349 UTC [64] LOG:  database system was shut down at 2024-02-03 18:54:51 UTC
postgres-1               | 2024-02-03 18:54:51.353 UTC [1] LOG:  database system is ready to accept connections
golem-service-1          | 2024-02-03T18:54:51.668526Z  INFO golem_service::db: DB Pool: postgresql://postgres:5432/golem_db
golem-service-1          | 2024-02-03T18:54:51.678530Z  INFO golem_service_base::service::template_object_store: FS Template Object Store root: /template_store, prefix:
golem-service-1          | 2024-02-03T18:54:51.686385Z  INFO poem::server: listening addr=socket://0.0.0.0:9881
golem-service-1          | 2024-02-03T18:54:51.686408Z  INFO poem::server: server started
```