### PR TITLE
Worker Connect Fixes

### DIFF
--- a/golem-service/src/api/worker_connect.rs
+++ b/golem-service/src/api/worker_connect.rs
@@ -1,11 +1,12 @@
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
-use crate::service::worker::WorkerService;
+use crate::service::worker::{ConnectWorkerStream, WorkerService};
 use futures_util::{SinkExt, StreamExt};
+use golem_api_grpc::proto::golem::worker::LogEvent;
 use golem_common::model::TemplateId;
 use golem_service_base::model::WorkerId;
-use poem::web::websocket::{CloseCode, Message, WebSocket, WebSocketStream};
+use poem::web::websocket::{Message, WebSocket, WebSocketStream};
 use poem::web::Data;
 use poem::*;
 use tonic::Status;
@@ -24,54 +25,118 @@ impl ConnectService {
 #[handler]
 pub async fn ws(
     req: &Request,
-    web_socket: WebSocket,
+    websocket: WebSocket,
     Data(service): Data<&ConnectService>,
 ) -> Response {
     tracing::info!("Connect request: {:?} {:?}", req.uri(), req);
 
-    let worker_id = match get_worker_id(req) {
-        Ok(worker_id) => worker_id,
-        Err(err) => return (http::StatusCode::BAD_REQUEST, err.0).into_response(),
-    };
-
-    let service = service.clone();
-
-    web_socket
-        .on_upgrade(move |mut socket| async move {
-            tokio::spawn(async move {
-                let result = try_proxy_worker_connection(&service, worker_id, &mut socket).await;
-                match result {
-                    Ok(()) => {
-                        tracing::info!("Worker connection closed");
-                    }
-                    Err(err) => {
-                        tracing::error!("Error connecting to worker: {}", err);
-                        let close_message = format!("Error connecting to worker: {}", err);
-                        let message = Message::Close(Some((CloseCode::Error, close_message)));
-
-                        if let Err(e) = socket.send(message).await {
-                            tracing::error!("Failed to send closing frame: {}", e);
-                        }
-                    }
-                }
-            })
+    get_worker_stream(service, req)
+        .await
+        .map(|(worker_id, worker_stream)| {
+            websocket
+                .on_upgrade(move |socket| {
+                    tokio::spawn(async move {
+                        proxy_worker_connection(worker_id, worker_stream, socket).await;
+                    })
+                })
+                .into_response()
         })
-        .into_response()
+        .unwrap_or_else(|err| err)
 }
 
-async fn try_proxy_worker_connection(
+async fn get_worker_stream(
     service: &ConnectService,
-    worker_id: WorkerId,
-    socket: &mut WebSocketStream,
-) -> Result<(), ConnectError> {
-    let mut stream = service.worker_service.connect(&worker_id).await?;
+    req: &Request,
+) -> Result<(WorkerId, ConnectWorkerStream), Response> {
+    let worker_id = match get_worker_id(req) {
+        Ok(worker_id) => worker_id,
+        Err(err) => return Err((http::StatusCode::BAD_REQUEST, err.0).into_response()),
+    };
 
-    while let Some(msg) = stream.next().await {
-        let message = msg?;
-        let msg_json = serde_json::to_string(&message)?;
-        socket.send(Message::Text(msg_json)).await?;
+    let worker_stream = service
+        .worker_service
+        .connect(&worker_id)
+        .await
+        .map_err(|e| (http::StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok((worker_id, worker_stream))
+}
+
+#[tracing::instrument(skip_all, fields(worker_id = worker_id.to_string()))]
+async fn proxy_worker_connection(
+    worker_id: golem_service_base::model::WorkerId,
+    mut worker_stream: ConnectWorkerStream,
+    mut websocket: WebSocketStream,
+) {
+    tracing::info!("Connecting to worker: {worker_id}");
+
+    let result = loop {
+        tokio::select! {
+            // WebSocket is cancellation safe.
+            // https://github.com/snapview/tokio-tungstenite/issues/167
+            websocket_message = websocket.next() => {
+                match websocket_message {
+                    Some(Ok(Message::Close(payload))) => {
+                        tracing::info!("Client closed WebSocket connection: {payload:?}");
+                        break Ok(());
+                    }
+
+                    Some(Ok(Message::Ping(_))) => {
+                        tracing::info!("Received PING");
+                        if let Err(error) = websocket.send(Message::Pong(Vec::new())).await{
+                            tracing::info!("Error sending PONG: {error}");
+                            break Err(error.into());
+                        }
+                    }
+                    Some(Err(error)) => {
+                        let error: ConnectError = error.into();
+                        tracing::info!("Received WebSocket Error: {error}");
+                        break Err(error);
+                    },
+                    Some(Ok(_)) => {}
+                    None => {
+                        tracing::info!("WebSocket connection closed");
+                        break Ok(());
+                    }
+                }
+            },
+
+            worker_message = worker_stream.next() => {
+                if let Some(message) = worker_message {
+                    if let Err(error) = forward_worker_message(message, &mut websocket).await {
+                        tracing::info!("Error forwarding message to WebSocket client: {error}");
+                        break(Err(error))
+                    }
+                } else {
+                    tracing::info!("Worker Stream ended");
+                    break Ok(());
+                }
+            },
+        }
+    };
+
+    if let Err(ref error) = result {
+        tracing::info!("Error proxying worker: {worker_id} {error}");
     }
 
+    if let Err(error) = websocket.close().await {
+        tracing::info!("Error closing WebSocket connection: {error}");
+    } else {
+        tracing::info!("WebSocket connection successfully closed");
+    }
+}
+
+async fn forward_worker_message<S, E>(
+    message: Result<LogEvent, tonic::Status>,
+    socket: &mut S,
+) -> Result<(), ConnectError>
+where
+    S: futures_util::Sink<Message, Error = E> + Unpin,
+    ConnectError: From<E>,
+{
+    let message = message?;
+    let msg_json = serde_json::to_string(&message)?;
+    socket.send(Message::Text(msg_json)).await?;
     Ok(())
 }
 

--- a/golem-service/src/service/worker.rs
+++ b/golem-service/src/service/worker.rs
@@ -34,12 +34,50 @@ use golem_service_base::typechecker::{TypeCheckIn, TypeCheckOut};
 use golem_service_base::worker_executor_clients::WorkerExecutorClients;
 
 pub struct ConnectWorkerStream {
-    streaming: Streaming<LogEvent>,
+    stream: tokio_stream::wrappers::ReceiverStream<Result<LogEvent, Status>>,
+    cancel: tokio_util::sync::CancellationToken,
 }
 
 impl ConnectWorkerStream {
     pub fn new(streaming: Streaming<LogEvent>) -> Self {
-        Self { streaming }
+        // Create a channel which is Send and Sync.
+        // Streaming is not Sync.
+        let (sender, receiver) = tokio::sync::mpsc::channel(32);
+        let mut streaming = streaming;
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+
+        tokio::spawn({
+            let cancel = cancel.clone();
+
+            let forward_loop = {
+                let sender = sender.clone();
+                async move {
+                    while let Some(message) = streaming.next().await {
+                        if let Err(error) = sender.send(message).await {
+                            tracing::info!("Failed to forward WorkerStream: {error}");
+                            break;
+                        }
+                    }
+                }
+            };
+
+            async move {
+                tokio::select! {
+                    _ = cancel.cancelled() => {
+                        tracing::info!("WorkerStream cancelled");
+                    }
+                    _ = forward_loop => {
+                        tracing::info!("WorkerStream forward loop finished");
+                    }
+                };
+                sender.closed().await;
+            }
+        });
+
+        let stream = tokio_stream::wrappers::ReceiverStream::new(receiver);
+
+        Self { stream, cancel }
     }
 }
 
@@ -50,7 +88,13 @@ impl Stream for ConnectWorkerStream {
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Result<LogEvent, Status>>> {
-        self.streaming.poll_next_unpin(cx)
+        self.stream.poll_next_unpin(cx)
+    }
+}
+
+impl Drop for ConnectWorkerStream {
+    fn drop(&mut self) {
+        self.cancel.cancel();
     }
 }
 


### PR DESCRIPTION
- Close connection with worker on client websocket close
- Forward stream to via mpsc channel which is Send + Sync, allowing for validation prior to upgradin the protocol to websocketg (because it can then be moved into future), and returning an http error. 
