### PR TITLE
Add get_all Redis impl + RegisterService get_all_versions 

### DIFF
--- a/golem-common/src/redis.rs
+++ b/golem-common/src/redis.rs
@@ -173,6 +173,16 @@ impl<'a> RedisLabelledApi<'a> {
         )
     }
 
+    pub async fn mget<R, K>(&self, keys: K) -> RedisResult<R>
+    where
+        R: FromRedis,
+        K: Into<MultipleKeys> + Send,
+    {
+        self.ensure_connected().await?;
+        let start = Instant::now();
+        self.record(start, "MGET", self.pool.mget(keys).await)
+    }
+
     pub async fn hdel<R, K, F>(&self, key: K, fields: F) -> RedisResult<R>
     where
         R: FromRedis,

--- a/golem-worker-bridge/src/register.rs
+++ b/golem-worker-bridge/src/register.rs
@@ -315,10 +315,7 @@ impl RegisterApiDefinition for RedisApiRegistry {
             futures::future::try_join_all(futures).await?
         };
 
-        Ok(all_definitions
-            .into_iter()
-            .filter_map(std::convert::identity)
-            .collect::<Vec<_>>())
+        Ok(all_definitions.into_iter().flatten().collect::<Vec<_>>())
     }
 
     async fn get_all_versions(
@@ -349,10 +346,7 @@ impl RegisterApiDefinition for RedisApiRegistry {
             .await
             .map_err(|e| ApiRegistrationError::InternalError(e.to_string()))?;
 
-        Ok(api_definitions
-            .into_iter()
-            .filter_map(std::convert::identity)
-            .collect())
+        Ok(api_definitions.into_iter().flatten().collect())
     }
 }
 


### PR DESCRIPTION
Introduces 2 new sets to aid in API Definition lookup
   - One for all API Definitions
   - One for all versions for a specific API Definition 

Introduces Transaction helper to have transactional guarantees in redis 

This can be further optimized using MGET to retrieve all API Definitions or using LUA scripting for a transaction. 